### PR TITLE
fix: Move iam_role_additional_policies

### DIFF
--- a/eks.tf
+++ b/eks.tf
@@ -11,10 +11,10 @@ module "eks" {
 
   eks_managed_node_group_defaults = {
     ami_type = "AL2_x86_64"
-  }
 
-  iam_role_additional_policies = {
-    additional_node_group_policy  = aws_iam_policy.iam_policy_for_eks_node_group.arn
+    iam_role_additional_policies = {
+      additional_node_group_policy  = aws_iam_policy.iam_policy_for_eks_node_group.arn
+    }
   }
 
   eks_managed_node_groups = {


### PR DESCRIPTION
Movendo regra de `iam_role_additional_policies` para ser adicionado ao node group e não ao cluster